### PR TITLE
Handle end-of-topic condition and update currentCycleNumber logic.

### DIFF
--- a/contracts/Topic.sol
+++ b/contracts/Topic.sol
@@ -53,7 +53,12 @@ contract Topic is ITopic {
         return choices.length;
     }
 
-    function currentCycleNumber() external view returns (uint256) {
-        return (block.timestamp - startTime) / cycleDuration;
+    function currentCycleNumber() external view returns (uint256 cycle, bool isOver) {
+        cycle = (block.timestamp - startTime) / cycleDuration; // reverts if block.timestamp < startTime
+
+        if (cycle >= totalCycles) {
+            cycle = totalCycles - 1;
+            isOver = true;
+        }
     }
 }

--- a/contracts/interfaces/ITopic.sol
+++ b/contracts/interfaces/ITopic.sol
@@ -21,5 +21,5 @@ interface ITopic {
 
     function arena() external view returns (address);
 
-    function currentCycleNumber() external view returns (uint256);
+    function currentCycleNumber() external view returns (uint256, bool); // cycle, isOver
 }


### PR DESCRIPTION
#### Updates:
- **Cycles Check:** Prevent users from contributing once the cycles for a topic have concluded.

- **`currentCycleNumber` Function:** 
  - Now always returns the last cycle if the topic is over.
  - Introduces an `isOver` flag to indicate the topic's end status.